### PR TITLE
Convert lead to person

### DIFF
--- a/prospyr/mixins.py
+++ b/prospyr/mixins.py
@@ -131,6 +131,28 @@ class Deletable(object):
         else:
             raise ApiError(resp.status_code, resp.text)
 
+class Convertable(object):
+    """
+    Allows conversion of a Lead. Should be mixed in with that class.
+    This only applies to Leads!
+    """
+
+    _convert_success_codes = {codes.ok}
+
+    def convert(self, using='default'):
+        """
+        Convert this Lead. True on success.
+        """
+        if getattr(self, 'id', None) is None:
+            raise ValueError('%s cannot be converted before it is saved' % self)
+        conn = self._get_conn(using)
+        path = self.Meta.convert_path.format(id=self.id)
+        resp = conn.convert(conn.build_absolute_url(path))
+        if resp.status_code in self._convert_success_codes:
+            return True
+        else:
+            raise ApiError(resp.status_code, resp.text)
+
 
 class ReadWritable(Creatable, Readable, Updateable, Deletable):
     pass

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -145,7 +145,6 @@ class PersonManager(Manager):
             )
             if resp.status_code not in {codes.ok}:
                 raise ApiError(resp.status_code, resp.text)
-            print(resp.json())
             return self.resource_cls.from_api_data(resp.json())
         raise ProspyrException("id or email is required when getting a Person")
 
@@ -669,7 +668,11 @@ class LeadManager(Manager):
             )
             if resp.status_code not in {codes.ok}:
                 raise ApiError(resp.status_code, resp.text)
-            print(resp.json())
+            if type(resp.json()) == list:
+                if not resp.json():
+                    raise ApiError(resp.status_code, 'Response was: %s. Resource not found.' % resp.text)
+                if len(resp.json()) == 1:
+                    return self.resource_cls.from_api_data(resp.json()[0])
             return self.resource_cls.from_api_data(resp.json())
         raise ProspyrException("id or email is required when getting a Lead")
 

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -655,6 +655,21 @@ class Task(Resource, mixins.ReadWritable):
     date_created = Unix()
     date_modified = Unix()
 
+class LeadManager(Manager):
+    def get(self, id=None, email=None):
+        if id is not None:
+            return super(LeadManager, self).get(id)
+        elif email is not None:
+            conn = connection.get(self.using)
+            path = self.resource_cls.Meta.search_path
+            resp = conn.post(
+                conn.build_absolute_url(path),
+                json={'emails': email}
+            )
+            if resp.status_code not in {codes.ok}:
+                raise ApiError(resp.status_code, resp.text)
+            return self.resource_cls.from_api_data(resp.json())
+        raise ProspyrException("id or email is required when getting a Lead")
 
 class Lead(Resource, mixins.ReadWritable):
     class Meta:
@@ -702,6 +717,8 @@ class Lead(Resource, mixins.ReadWritable):
     )
     date_created = Unix()
     date_modified = Unix()
+
+    objects = LeadManager()
 
 
 class Account(Resource, mixins.Singleton):

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -677,7 +677,7 @@ class LeadManager(Manager):
         raise ProspyrException("id or email is required when getting a Lead")
 
 
-class Lead(Resource, mixins.ReadWritable):
+class Lead(Resource, mixins.ReadWritable, mixins.Convertable):
     class Meta:
         create_path = 'leads/'
         search_path = 'leads/search'
@@ -726,15 +726,6 @@ class Lead(Resource, mixins.ReadWritable):
     date_modified = Unix()
 
     objects = LeadManager()
-
-    def convert(self): #Should probably move this to a Manager Method
-        conn = connection.get('default') #Not ideal for those who need multiple connections
-        path = 'leads/%s/convert' % self.id
-        resp = conn.post(
-            conn.build_absolute_url(path)
-        )
-        if resp.status_code not in {codes.ok}:
-            raise ApiError(resp.status_code, resp.text)
 
 
 class Account(Resource, mixins.Singleton):

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -145,6 +145,7 @@ class PersonManager(Manager):
             )
             if resp.status_code not in {codes.ok}:
                 raise ApiError(resp.status_code, resp.text)
+            print(resp.json())
             return self.resource_cls.from_api_data(resp.json())
         raise ProspyrException("id or email is required when getting a Person")
 
@@ -668,6 +669,7 @@ class LeadManager(Manager):
             )
             if resp.status_code not in {codes.ok}:
                 raise ApiError(resp.status_code, resp.text)
+            print(resp.json())
             return self.resource_cls.from_api_data(resp.json())
         raise ProspyrException("id or email is required when getting a Lead")
 

--- a/prospyr/resources.py
+++ b/prospyr/resources.py
@@ -676,11 +676,13 @@ class LeadManager(Manager):
             return self.resource_cls.from_api_data(resp.json())
         raise ProspyrException("id or email is required when getting a Lead")
 
+
 class Lead(Resource, mixins.ReadWritable):
     class Meta:
         create_path = 'leads/'
         search_path = 'leads/search'
         detail_path = 'leads/{id}'
+        convert_path = 'leads/{id}/convert'
         order_fields = {
             'name',
             'assignee',
@@ -724,6 +726,15 @@ class Lead(Resource, mixins.ReadWritable):
     date_modified = Unix()
 
     objects = LeadManager()
+
+    def convert(self): #Should probably move this to a Manager Method
+        conn = connection.get('default') #Not ideal for those who need multiple connections
+        path = 'leads/%s/convert' % self.id
+        resp = conn.post(
+            conn.build_absolute_url(path)
+        )
+        if resp.status_code not in {codes.ok}:
+            raise ApiError(resp.status_code, resp.text)
 
 
 class Account(Resource, mixins.Singleton):


### PR DESCRIPTION
Makes use of the /convert endpoint provided by ProsperWorks. This endpoint converts a Lead to a Person, actually moving the resource so that it is only in one place. 